### PR TITLE
feat(anagram-tracking): add progress tracking + summary; fix route hierarchy

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -58,7 +58,33 @@ const userSchema = new mongoose.Schema({
   }
 }, { timestamps: true });
 
+// Individual anagram session schema
+const AnagramSessionSchema = new mongoose.Schema({
+  sessionId: { type: String, index: true },
+  topic: { type: String, default: 'All' },
+  startedAt: { type: Date, required: true },
+  finishedAt: { type: Date, required: true },
+  durationMs: { type: Number, required: true },
+  totalAttempted: { type: Number, required: true },
+  totalCorrect: { type: Number, required: true },
+  accuracyPct: { type: Number, required: true }, // 0..1
+  targetCount: { type: Number, default: 25 },
+}, { _id: false });
 
+// Aggregated stats schema
+const AnagramStatsSchema = new mongoose.Schema({
+  totalSetsCompleted: { type: Number, default: 0 },
+  bestAccuracy: { type: Number, default: 0 },
+  avgAccuracy: { type: Number, default: 0 },
+  bestAvgTimeMs: { type: Number, default: null },
+  avgTimeMs: { type: Number, default: null },
+}, { _id: false });
+
+// Append to main userSchema
+userSchema.add({
+  anagramSessions: { type: [AnagramSessionSchema], default: [] },
+  anagramStats: { type: AnagramStatsSchema, default: () => ({}) },
+});
 
 
 // password hashing pre-save middleware

--- a/server/routes/api/userRoutes.js
+++ b/server/routes/api/userRoutes.js
@@ -9,7 +9,8 @@ const {
   updateUserProfile,
   deleteUser,
   getAllUsers,
-  updateAnagramProgress
+  updateAnagramProgress,
+  getAnagramSummary,
 } = require('../../controllers/userController');
 const { verifyToken, validateSignup, requireAdmin } = require('../../middleware/authMiddleware');
 
@@ -43,8 +44,9 @@ router.get('/profile', verifyToken, getUserProfile);
 // PUT /api/users/profile - Update user profile (Protected)
 router.put('/profile', verifyToken, updateUserProfile);
 
-// PATCH /api/users/progress/anagram - Update anagram progress (Protected)
+// PROGRESS ROUTES (Protected)
 router.patch('/progress/anagram', verifyToken, updateAnagramProgress);
+router.get('/progress/anagram/summary', verifyToken, getAnagramSummary);
 
 // DELETE /api/users/:userId - Delete user account (Protected)
 router.delete('/:userId', verifyToken, deleteUser);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -11,7 +11,7 @@ const apiRoutes = require('./api');
 // protected routes
 router.use('/protected', protectedRoutes);
 
-// api routes
-router.use('/api', apiRoutes);
+// main api routes
+router.use('/', apiRoutes);
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,12 +1,22 @@
 const path = require("path");
-require("dotenv").config(({ path: path.resolve(__dirname, ".env") }));
+require("dotenv").config({ path: path.resolve(__dirname, ".env") });
+
 console.log("SERVER STARTING");
 console.log("JWT_SECRET Loaded:", process.env.JWT_SECRET || "NOT LOADED!");
 
 const cors = require("cors");
 const express = require("express");
 const connectDB = require("./config/connection");
-const routes = require("./routes/api");
+
+// Initialize Express app (do this BEFORE app.use)
+const app = express();
+
+// CORS + JSON
+app.use(cors({
+  origin: "http://localhost:5173",
+  credentials: true,
+}));
+app.use(express.json());
 
 // Ensure .env variables are properly loaded
 if (!process.env.JWT_SECRET) {
@@ -14,24 +24,14 @@ if (!process.env.JWT_SECRET) {
   process.exit(1);
 }
 
-// Initialize Express app
-const app = express();
-app.use(cors({
-  origin: "http://localhost:5173",
-  credentials: true
-}));
-
-app.use(express.json()); // JSON parsing middleware
-
-
 // Connect to MongoDB
 connectDB();
-
-// Register routes
-app.use("/api", routes);
-
-// Log database connection
 console.log(" Using MongoDB URI:", process.env.MONGODB_URI);
+
+// Mount routes ONCE
+// ./routes/index.js already wires /api, /protected, etc.
+const routes = require("./routes");
+app.use("/", routes);
 
 // Start server
 const PORT = process.env.PORT || 3001;
@@ -39,7 +39,7 @@ app.listen(PORT, () => {
   console.log(` Server running on http://localhost:${PORT}`);
 });
 
-// Handle all unhandled errors
+// Global error guards
 process.on("uncaughtException", (err) => {
   console.error("UNCAUGHT EXCEPTION:", err);
 });


### PR DESCRIPTION
## Overview
This PR introduces anagram practice tracking and a lightweight summary endpoint.

### What’s included
- Controller:
  - `updateAnagramProgress` (PATCH): accepts { sessionId?, topic, startedAt, finishedAt, totalAttempted, totalCorrect } with defensive checks (no negatives; correct ≤ attempted). Computes duration + accuracy and stores a session.
  - `getAnagramSummary` (GET): returns rollups { totalSetsCompleted, bestAccuracy, avgAccuracy, bestAvgTimeMs|null, avgTimeMs|null }.
- Routes (`routes/api/userRoutes.js`):
  - `PATCH /api/users/progress/anagram` (protected)
  - `GET /api/users/progress/anagram/summary` (protected)
- Server wiring (`server.js`):
  - Single mount `app.use("/", routes)`; removed redundant double `/api` mounts.
  - CORS + JSON middleware ordering confirmed.
- Small logging improvements for easier debugging.

### Why
- Enables backend persistence and quick dashboard summaries for anagram practice.
- Cleans up route hierarchy to avoid duplicate prefixes and confusing paths.

### Testing (Insomnia)
- ✅ PATCH /api/users/progress/anagram: returns `{ success, stats, latestSession }`
- ✅ GET /api/users/progress/anagram/summary: returns `{ success, summary }`
- ✅ Auth flows (signup/signin/refresh/logout) smoke-tested.

### Notes
- `bestAvgTimeMs` and `avgTimeMs` are `null` when no timing data yet (UI can render `--:--`).
- No breaking changes for existing clients that hit `/api/users/*`.

### Follow-ups (next milestone)
- FE: connect summary endpoint to dashboard widgets (accuracy %, best time, average time).
- Add pagination on `anagramSessions` if needed.
- Optional: add date range filters for summaries (`?from=&to=`).

### Checklist
- [x] Compiles locally
- [x] Env vars verified (JWT_SECRET, MONGODB_URI)
- [x] Insomnia tests attached (see screenshots)
- [x] No duplicate route mounts